### PR TITLE
Make tests python version agnostic, ignore case

### DIFF
--- a/Python/Makefile
+++ b/Python/Makefile
@@ -1,4 +1,4 @@
 FILES = $(wildcard *.py)
 
 test:
-	$(foreach testable, $(FILES), echo "Testing $(testable)"; python $(testable) | diff - ../fizzbuzz.txt;)
+	$(foreach testable, $(FILES), echo "Testing $(testable)"; ./$(testable) | diff -i - ../fizzbuzz.txt;)

--- a/Python/fb.py
+++ b/Python/fb.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python2
+
 for x in range(100):
     if x%3 == 0 and x%5 == 0:
         print "FizzBuzz"

--- a/Python/kline.py
+++ b/Python/kline.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python2
+
 def fizzbuzz(foo):
     t = xrange(0, foo+1, 3) #xrange to increase performance
     f = xrange(0, foo+1, 5)


### PR DESCRIPTION
Some tests fail because they are python2 and 'python' might be a symlink
to python3. One idea is to make them executable, add a shebang and run them with ./. I
am not sure whether there is a way to do that without making them
executable. Some others fail because the case is not the same as the
reference file. Passing -i to diff should fix that.
