### PR TITLE
Adding K8s parallel distributed Fizzbuzz

### DIFF
--- a/k8s/fizzbuzz.yaml
+++ b/k8s/fizzbuzz.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fizzbuzz
+spec:
+  completions: 100
+  parallelism: 10
+  completionMode: Indexed
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: fizzbuzz
+          image: debian:latest
+          command:
+            - "bash"
+            - "-c"
+            - |
+              if [[ "$JOB_COMPLETION_INDEX % 15" -eq 0 ]]; then
+                echo FizzBuzz
+              elif [[ "$JOB_COMPLETION_INDEX % 3" -eq 0 ]]; then
+                echo Fizz
+              elif [[ "$JOB_COMPLETION_INDEX % 5" -eq 0 ]]; then
+                echo Buzz
+              else
+                echo $JOB_COMPLETION_INDEX
+              fi


### PR DESCRIPTION
Created a FizzBuzz for the cloud. Tested and works fine in minikube, takes approximately 2m 30s on my machine. Enterprise grade efficiency is achieved.

Simply deploy with `kubectl apply -f fizzbuzz.yaml`, results can be gathered by examining the logs of each individually launched pod.